### PR TITLE
T/28: Italic renderer should be changed to <i> to match Editor Recommendations

### DIFF
--- a/src/italicengine.js
+++ b/src/italicengine.js
@@ -37,7 +37,7 @@ export default class ItalicEngine extends Plugin {
 		// Build converter from model to view for data and editing pipelines.
 		buildModelConverter().for( data.modelToView, editing.modelToView )
 			.fromAttribute( ITALIC )
-			.toElement( 'em' );
+			.toElement( 'i' );
 
 		// Build converter from view to model for data pipeline.
 		buildViewConverter().for( data.viewToModel )

--- a/tests/italicengine.js
+++ b/tests/italicengine.js
@@ -53,7 +53,7 @@ describe( 'ItalicEngine', () => {
 			expect( getModelData( doc, { withoutSelection: true } ) )
 				.to.equal( '<paragraph><$text italic="true">foo</$text>bar</paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p><em>foo</em>bar</p>' );
+			expect( editor.getData() ).to.equal( '<p><i>foo</i>bar</p>' );
 		} );
 
 		it( 'should convert <i> to italic attribute', () => {
@@ -62,7 +62,7 @@ describe( 'ItalicEngine', () => {
 			expect( getModelData( doc, { withoutSelection: true } ) )
 				.to.equal( '<paragraph><$text italic="true">foo</$text>bar</paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p><em>foo</em>bar</p>' );
+			expect( editor.getData() ).to.equal( '<p><i>foo</i>bar</p>' );
 		} );
 
 		it( 'should convert font-weight:italic to italic attribute', () => {
@@ -71,7 +71,7 @@ describe( 'ItalicEngine', () => {
 			expect( getModelData( doc, { withoutSelection: true } ) )
 				.to.equal( '<paragraph><$text italic="true">foo</$text>bar</paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p><em>foo</em>bar</p>' );
+			expect( editor.getData() ).to.equal( '<p><i>foo</i>bar</p>' );
 		} );
 
 		it( 'should be integrated with autoparagraphing', () => {
@@ -90,7 +90,7 @@ describe( 'ItalicEngine', () => {
 		it( 'should convert attribute', () => {
 			setModelData( doc, '<paragraph><$text italic="true">foo</$text>bar</paragraph>' );
 
-			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<p><em>foo</em>bar</p>' );
+			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<p><i>foo</i>bar</p>' );
 		} );
 	} );
 } );

--- a/tests/manual/basic-styles.html
+++ b/tests/manual/basic-styles.html
@@ -1,3 +1,3 @@
 <div id="editor">
-	<p><em>This</em> is an <strong>editor</strong> instance.</p>
+	<p><i>This</i> is an <strong>editor</strong> instance.</p>
 </div>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Italic renderer will use `<i>` instead of `<em>`. Closes #28.

Read more about it in [Editor Recommendations](https://github.com/ckeditor/editor-recommendations/issues/2#issuecomment-243758620).

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
