### PR TITLE
T/49: Add an integration test for checking an attribute command for object element 

### DIFF
--- a/tests/attributecommand.js
+++ b/tests/attributecommand.js
@@ -30,6 +30,7 @@ describe( 'AttributeCommand', () => {
 				doc.schema.registerItem( 'p', '$block' );
 				doc.schema.registerItem( 'h1', '$block' );
 				doc.schema.registerItem( 'img', '$inline' );
+				doc.schema.objects.add( 'img' );
 
 				// Allow block in "root" (DIV)
 				doc.schema.allow( { name: '$block', inside: '$root' } );
@@ -64,6 +65,23 @@ describe( 'AttributeCommand', () => {
 			} );
 
 			expect( command.value ).to.be.false;
+		} );
+
+		it( 'is false when selection contains object with nested editable', () => {
+			doc.schema.registerItem( 'caption', '$block' );
+			doc.schema.allow( { name: '$inline', inside: 'caption' } );
+			doc.schema.allow( { name: 'caption', inside: 'img' } );
+			doc.schema.allow( { name: '$text', attributes: 'bold', inside: 'caption' } );
+
+			setData( doc, '<p>[<img><caption>Some caption inside the image.</caption></img>]</p>' );
+
+			expect( command.value ).to.be.false;
+			command.execute();
+			expect( command.value ).to.be.false;
+
+			expect( getData( doc ) ).to.equal(
+				'<p>[<img><caption><$text bold="true">Some caption inside the image.</$text></caption></img>]</p>'
+			);
 		} );
 	} );
 

--- a/tests/attributecommand.js
+++ b/tests/attributecommand.js
@@ -67,6 +67,7 @@ describe( 'AttributeCommand', () => {
 			expect( command.value ).to.be.false;
 		} );
 
+		// See https://github.com/ckeditor/ckeditor5-core/issues/73#issuecomment-311572827.
 		it( 'is false when selection contains object with nested editable', () => {
 			doc.schema.registerItem( 'caption', '$block' );
 			doc.schema.allow( { name: '$inline', inside: 'caption' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Added test which checks whether the selection has proper attributes for objects with nested editable. Closes #49.

---

Requires: https://github.com/ckeditor/ckeditor5-engine/pull/990