### PR TITLE
Marked basic style attributes with the AttributeProperties#isFormatting property

### DIFF
--- a/src/bold/boldediting.js
+++ b/src/bold/boldediting.js
@@ -28,6 +28,7 @@ export default class BoldEditing extends Plugin {
 		const editor = this.editor;
 		// Allow bold attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: BOLD } );
+		editor.model.schema.setAttributeProperties( BOLD, { isFormatting: true } );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/code/codeediting.js
+++ b/src/code/codeediting.js
@@ -29,6 +29,7 @@ export default class CodeEditing extends Plugin {
 
 		// Allow code attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: CODE } );
+		editor.model.schema.setAttributeProperties( CODE, { isFormatting: true } );
 
 		editor.conversion.attributeToElement( {
 			model: CODE,

--- a/src/italic/italicediting.js
+++ b/src/italic/italicediting.js
@@ -29,6 +29,7 @@ export default class ItalicEditing extends Plugin {
 
 		// Allow italic attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: ITALIC } );
+		editor.model.schema.setAttributeProperties( ITALIC, { isFormatting: true } );
 
 		editor.conversion.attributeToElement( {
 			model: ITALIC,

--- a/src/strikethrough/strikethroughediting.js
+++ b/src/strikethrough/strikethroughediting.js
@@ -30,6 +30,7 @@ export default class StrikethroughEditing extends Plugin {
 
 		// Allow strikethrough attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: STRIKETHROUGH } );
+		editor.model.schema.setAttributeProperties( STRIKETHROUGH, { isFormatting: true } );
 
 		editor.conversion.attributeToElement( {
 			model: STRIKETHROUGH,

--- a/src/subscript/subscriptediting.js
+++ b/src/subscript/subscriptediting.js
@@ -28,6 +28,7 @@ export default class SubscriptEditing extends Plugin {
 		const editor = this.editor;
 		// Allow sub attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: SUBSCRIPT } );
+		editor.model.schema.setAttributeProperties( SUBSCRIPT, { isFormatting: true } );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/superscript/superscriptediting.js
+++ b/src/superscript/superscriptediting.js
@@ -28,6 +28,7 @@ export default class SuperscriptEditing extends Plugin {
 		const editor = this.editor;
 		// Allow super attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: SUPERSCRIPT } );
+		editor.model.schema.setAttributeProperties( SUPERSCRIPT, { isFormatting: true } );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/underline/underlineediting.js
+++ b/src/underline/underlineediting.js
@@ -29,6 +29,7 @@ export default class UnderlineEditing extends Plugin {
 
 		// Allow strikethrough attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: UNDERLINE } );
+		editor.model.schema.setAttributeProperties( UNDERLINE, { isFormatting: true } );
 
 		editor.conversion.attributeToElement( {
 			model: UNDERLINE,

--- a/tests/bold/boldediting.js
+++ b/tests/bold/boldediting.js
@@ -40,6 +40,12 @@ describe( 'BoldEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'bold' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'bold' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	it( 'should set editor keystroke', () => {
 		const spy = sinon.spy( editor, 'execute' );
 		const keyEventData = {

--- a/tests/code/codeediting.js
+++ b/tests/code/codeediting.js
@@ -39,6 +39,12 @@ describe( 'CodeEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'code' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'code' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register code command', () => {
 			const command = editor.commands.get( 'code' );

--- a/tests/italic/italicediting.js
+++ b/tests/italic/italicediting.js
@@ -39,6 +39,12 @@ describe( 'ItalicEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'italic' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'italic' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register italic command', () => {
 			const command = editor.commands.get( 'italic' );

--- a/tests/strikethrough/strikethroughediting.js
+++ b/tests/strikethrough/strikethroughediting.js
@@ -39,6 +39,12 @@ describe( 'StrikethroughEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'strikethrough' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'strikethrough' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register strikethrough command', () => {
 			const command = editor.commands.get( 'strikethrough' );

--- a/tests/subscript/subscriptediting.js
+++ b/tests/subscript/subscriptediting.js
@@ -39,6 +39,12 @@ describe( 'SubEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'subscript' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'subscript' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register subscript command', () => {
 			const command = editor.commands.get( 'subscript' );

--- a/tests/superscript/superscriptediting.js
+++ b/tests/superscript/superscriptediting.js
@@ -39,6 +39,12 @@ describe( 'SuperEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'superscript' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'superscript' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register superscript command', () => {
 			const command = editor.commands.get( 'superscript' );

--- a/tests/underline/underlineediting.js
+++ b/tests/underline/underlineediting.js
@@ -39,6 +39,12 @@ describe( 'UnderlineEditing', () => {
 		expect( model.schema.checkAttribute( [ '$clipboardHolder', '$text' ], 'underline' ) ).to.be.true;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( model.schema.getAttributeProperties( 'underline' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'command', () => {
 		it( 'should register underline command', () => {
 			const command = editor.commands.get( 'underline' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Marked basic style attributes as a formatting using the `AttributeProperties#isFormatting` property. Closes ckeditor/ckeditor5#1664.

---

### Additional information

There are 2 more pull requests related with this in respective repositories.

All The PRs are referenced in ckeditor/ckeditor5#1664.