### PR TITLE
Mark basic-styles attributes with 'copyOnEnter' property

### DIFF
--- a/src/bold/boldediting.js
+++ b/src/bold/boldediting.js
@@ -28,7 +28,10 @@ export default class BoldEditing extends Plugin {
 		const editor = this.editor;
 		// Allow bold attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: BOLD } );
-		editor.model.schema.setAttributeProperties( BOLD, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( BOLD, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/code/codeediting.js
+++ b/src/code/codeediting.js
@@ -29,7 +29,10 @@ export default class CodeEditing extends Plugin {
 
 		// Allow code attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: CODE } );
-		editor.model.schema.setAttributeProperties( CODE, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( CODE, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		editor.conversion.attributeToElement( {
 			model: CODE,

--- a/src/italic/italicediting.js
+++ b/src/italic/italicediting.js
@@ -29,7 +29,10 @@ export default class ItalicEditing extends Plugin {
 
 		// Allow italic attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: ITALIC } );
-		editor.model.schema.setAttributeProperties( ITALIC, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( ITALIC, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		editor.conversion.attributeToElement( {
 			model: ITALIC,

--- a/src/strikethrough/strikethroughediting.js
+++ b/src/strikethrough/strikethroughediting.js
@@ -30,7 +30,10 @@ export default class StrikethroughEditing extends Plugin {
 
 		// Allow strikethrough attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: STRIKETHROUGH } );
-		editor.model.schema.setAttributeProperties( STRIKETHROUGH, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( STRIKETHROUGH, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		editor.conversion.attributeToElement( {
 			model: STRIKETHROUGH,

--- a/src/subscript/subscriptediting.js
+++ b/src/subscript/subscriptediting.js
@@ -28,7 +28,10 @@ export default class SubscriptEditing extends Plugin {
 		const editor = this.editor;
 		// Allow sub attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: SUBSCRIPT } );
-		editor.model.schema.setAttributeProperties( SUBSCRIPT, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( SUBSCRIPT, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/superscript/superscriptediting.js
+++ b/src/superscript/superscriptediting.js
@@ -28,7 +28,10 @@ export default class SuperscriptEditing extends Plugin {
 		const editor = this.editor;
 		// Allow super attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: SUPERSCRIPT } );
-		editor.model.schema.setAttributeProperties( SUPERSCRIPT, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( SUPERSCRIPT, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		// Build converter from model to view for data and editing pipelines.
 

--- a/src/underline/underlineediting.js
+++ b/src/underline/underlineediting.js
@@ -29,7 +29,10 @@ export default class UnderlineEditing extends Plugin {
 
 		// Allow strikethrough attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: UNDERLINE } );
-		editor.model.schema.setAttributeProperties( UNDERLINE, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( UNDERLINE, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		editor.conversion.attributeToElement( {
 			model: UNDERLINE,

--- a/tests/bold/boldediting.js
+++ b/tests/bold/boldediting.js
@@ -41,8 +41,14 @@ describe( 'BoldEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'bold' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'bold' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'bold' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/code/codeediting.js
+++ b/tests/code/codeediting.js
@@ -40,8 +40,14 @@ describe( 'CodeEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'code' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'code' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'code' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/italic/italicediting.js
+++ b/tests/italic/italicediting.js
@@ -40,8 +40,14 @@ describe( 'ItalicEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'italic' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'italic' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'italic' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/strikethrough/strikethroughediting.js
+++ b/tests/strikethrough/strikethroughediting.js
@@ -40,8 +40,14 @@ describe( 'StrikethroughEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'strikethrough' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'strikethrough' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'strikethrough' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/subscript/subscriptediting.js
+++ b/tests/subscript/subscriptediting.js
@@ -40,8 +40,14 @@ describe( 'SubEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'subscript' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'subscript' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'subscript' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/superscript/superscriptediting.js
+++ b/tests/superscript/superscriptediting.js
@@ -40,8 +40,14 @@ describe( 'SuperEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'superscript' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'superscript' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'superscript' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/underline/underlineediting.js
+++ b/tests/underline/underlineediting.js
@@ -40,8 +40,14 @@ describe( 'UnderlineEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( model.schema.getAttributeProperties( 'underline' ) ).to.deep.equal( {
+		expect( model.schema.getAttributeProperties( 'underline' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( model.schema.getAttributeProperties( 'underline' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Mark basic-styles attributes with 'copyOnEnter' property.

---

### Additional information
* Requires: ckeditor/ckeditor5-enter#63
